### PR TITLE
build.py - Fix 'build.py libs' not actually initializing git submodules

### DIFF
--- a/build.py
+++ b/build.py
@@ -119,11 +119,11 @@ def __ensure_installed(module_name, version=None):
 def sync_libs(needs_lesscpy=False, needs_jsb=False):
     __create_dir_if_not_exists(LIBS_PATH)
     flag = False
-    if not os.path.exists(CLOSURE_LIBRARY_PATH) or \
-            not os.path.exists(GRAPHICS_PATH):
+    if not os.path.exists(os.path.join(CLOSURE_LIBRARY_PATH, ".git")) or \
+            not os.path.exists(os.path.join(GRAPHICS_PATH, ".git")):
         flag = True
         print 'Initializing submodules'
-        subprocess.call(['git', 'submodule', 'update', '--init'])
+        subprocess.call(['git', 'submodule', 'update', '--init', '--recursive'])
         subprocess.call(['rm', '-f', '.git/hooks/post-checkout'])
         subprocess.call(['ln', '-s', '../../update-submodules', '.git/hooks/post-checkout'])
         print 'Done'


### PR DESCRIPTION
After initial cloning and running "./build.py libs" the submodules directories always  exist, so checking for their existence will always succeed, but initially they will be empty. This will cause the submodules to not be updated and the build to fail.
Check instead for the existence of the .git file inside them.

Also, run 'git submodule update' with '--recursive' flag as the submodules also have their own submodules. Not doing this will also end up with failing builds