### PR TITLE
Public methods getOption/setOption for annotations

### DIFF
--- a/src/annotations/Base.js
+++ b/src/annotations/Base.js
@@ -1339,6 +1339,8 @@ anychart.annotationsModule.Base.prototype.disposeInternal = function() {
 //exports
 (function() {
   var proto = anychart.annotationsModule.Base.prototype;
+  proto['getOption'] = proto.getOption;//doc|ex
+  proto['setOption'] = proto.setOption;//doc|ex
   proto['getType'] = proto.getType;
   proto['getChart'] = proto.getChart;
   proto['getPlot'] = proto.getPlot;


### PR DESCRIPTION
Allows to store data for annotations. Useful when saving/retrieving the annotation definition from DB, you can store also the ID or record hash:

```
    _a = controller.ray({
        xAnchor: x1,
        valueAnchor: y1,
        secondXAnchor:  x2,
        secondValueAnchor: y2,
    });
    _a.setOption('externalId', 12345);

    // create an event listener for the annotationSelect event
    chart.listen("annotationSelect", function(e){
        window.setTimeout(() => {
            console.log(e.annotation.getOption('externalId'));            
        }, 10);
     });

```

Or save anything like a memo note, etc.